### PR TITLE
Empêcher l'affichage des fichiers de l'API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,6 @@
 RewriteEngine on
+RewriteCond %{REQUEST_URI} ^/rest_mediatekdocuments/?$
+RewriteRule ^$ - [R=400,L]
 RewriteCond %{REQUEST_METHOD} =GET
 RewriteRule ^([a-zA-Z0-9_]+)$ src/index.php?table=$1 [B,L]
 RewriteCond %{REQUEST_METHOD} =GET


### PR DESCRIPTION
Modification du fichier htaccess quand l'utilisateur visite http://localhost/rest_mediatekdocuments/ afin d'empêcher l'affichage des fichiers de l'API.